### PR TITLE
complete overhaul of the exercices for part 4

### DIFF
--- a/2019-04-Birmingham/Part4_Tactics_UniMath/exercises_tactics.v
+++ b/2019-04-Birmingham/Part4_Tactics_UniMath/exercises_tactics.v
@@ -1,10 +1,10 @@
 (** Exercise sheet for lecture 4: Tactics in Coq.
 
-Written by Ralph Matthes.
+Written by Ralph Matthes (CNRS, IRIT, Univ. Toulouse, France).
  *)
 
 (** * Exercise 1
-Formalize the solutions of exercise 1 of Lecture 1.
+Formalize the solutions of exercise 1 of Lecture 1 (of the 2017 UniMath school, given by Andrej Bauer).
 
 [[
 For each of the following types, write down an element of that type, if it has one. If it does not have any elements, you should establish that this is the case. But first think how this can be done in type theory! It ought to be just another construction.
@@ -24,15 +24,15 @@ For the present exercise, this means: state the formula as a lemma, give a proof
 
 More precise instructions and hints:
 
-1. Use ⨿ in place of the + and pay attention to operator precedence.
+1. Use [⨿] in place of the + and pay attention to operator precedence.
 
 2. Write a function that provides different elements for any natural number argument, not just five elements; for extra credits: state correctly that they are different - for a good choice of [A]; for more extra credits: prove that they are different.
 
 3. An auxiliary function may be helpful - better recall the trick.
 
-4. The symbol for Sigma-types is ∑, not Σ.
+4. The symbol for Sigma-types is [∑], not [Σ].
 
-5. Same as 1; and there is need for module UniMath.Foundations.NaturalNumbers, e.g., for Lemma natpluscomm.
+5. Same as 1; and there is need for module [UniMath.Foundations.NaturalNumbers], e.g., for Lemma [natpluscomm].
 
 6.-9. no further particulars
 *)
@@ -44,23 +44,26 @@ Require Import UniMath.Foundations.NaturalNumbers.
 
 
 (** * Exercise 2
-Define two computable strict comparison operators for natural numbers based on the fact that m < n iff
-n - m <> 0 iff (m+1) - n = 0. Prove that the two operators are equal (using function extensionality, i.e., [funextfunStatement] in the UniMath library).
+Define two computable strict comparison operators for natural numbers based on the fact
+that [m < n] iff [n - m <> 0] iff [(m+1) - n = 0]. Prove that the two operators are
+equal (using function extensionality, i.e., [funextfunStatement] in the UniMath library).
 
-It may be helpful to use the definitions of the exercises for lecture 2. The following lemmas on substraction sub in the natural numbers may be useful:
+It may be helpful to use the definitions of the exercises for lecture 2 (of the UniMath
+school 2017). The following lemmas on substraction [sub] in the natural numbers may be
+useful:
 
-a) sub n (S m) = pred (sub n m)
+a) [sub n (S m) = pred (sub n m)]
 
-b) sub 0 n = 0
+b) [sub 0 n = 0]
 
-c) pred (sub 1 n) = 0
+c) [pred (sub 1 n) = 0]
 
-d) sub (S n) (S m) = sub n m
+d) [sub (S n) (S m) = sub n m]
 
 *)
 
 
-(** from exercises to Lecture 2: *)
+(** from exercises to Lecture 2 (of the UniMath school 2017): *)
 Definition ifbool (A : UU) (x y : A) : bool -> A :=
   bool_rect (λ _ : bool, A) x y.
 

--- a/2019-04-Birmingham/Part4_Tactics_UniMath/exercises_tactics_with_solutions.v
+++ b/2019-04-Birmingham/Part4_Tactics_UniMath/exercises_tactics_with_solutions.v
@@ -2,11 +2,11 @@
 
 This is the material for the advisors with solutions.
 
-Written by Ralph Matthes.
- *)
+Written by Ralph Matthes (CNRS, IRIT, Univ. Toulouse, France).
+*)
 
 (** * Exercise 1
-Formalize the solutions of exercise 1 of Lecture 1.
+Formalize the solutions of exercise 1 of Lecture 1 (of the 2017 UniMath school, given by Andrej Bauer).
 
 [[
 For each of the following types, write down an element of that type, if it has one. If it does not have any elements, you should establish that this is the case. But first think how this can be done in type theory! It ought to be just another construction.
@@ -26,15 +26,15 @@ For the present exercise, this means: state the formula as a lemma, give a proof
 
 More precise instructions and hints:
 
-1. Use ⨿ in place of the + and pay attention to operator precedence.
+1. Use [⨿] in place of the + and pay attention to operator precedence.
 
 2. Write a function that provides different elements for any natural number argument, not just five elements; for extra credits: state correctly that they are different - for a good choice of [A]; for more extra credits: prove that they are different.
 
 3. An auxiliary function may be helpful - better recall the trick.
 
-4. The symbol for Sigma-types is ∑, not Σ.
+4. The symbol for Sigma-types is [∑], not [Σ].
 
-5. Same as 1; and there is need for module UniMath.Foundations.NaturalNumbers, e.g., for Lemma natpluscomm.
+5. Same as 1; and there is need for module [UniMath.Foundations.NaturalNumbers], e.g., for Lemma [natpluscomm].
 
 6.-9. no further particulars
 *)
@@ -66,7 +66,7 @@ Proof.
   - exact (f IH).
 Defined.
 
-(** of course, the iterator of lecture 2 could be used here *)
+(** of course, the iterator of lecture 2 (of the UniMath school 2017) could be used here *)
 
 Lemma Exo1_2_bonus (n1 n2: nat): ¬ (n1 = n2) -> ¬ (Exo1_2 nat n1 = Exo1_2 nat n2).
 Proof.
@@ -177,23 +177,26 @@ Proof.
 Defined.
 
 (** * Exercise 2
-Define two computable strict comparison operators for natural numbers based on the fact that m < n iff
-n - m <> 0 iff (m+1) - n = 0. Prove that the two operators are equal (using function extensionality, i.e., [funextfunStatement] in the UniMath library).
+Define two computable strict comparison operators for natural numbers based on the fact
+that [m < n] iff [n - m <> 0] iff [(m+1) - n = 0]. Prove that the two operators are
+equal (using function extensionality, i.e., [funextfunStatement] in the UniMath library).
 
-It may be helpful to use the definitions of the exercises for lecture 2. The following lemmas on substraction sub in the natural numbers may be useful:
+It may be helpful to use the definitions of the exercises for lecture 2 (of the UniMath
+school 2017). The following lemmas on substraction [sub] in the natural numbers may be
+useful:
 
-a) sub n (S m) = pred (sub n m)
+a) [sub n (S m) = pred (sub n m)]
 
-b) sub 0 n = 0
+b) [sub 0 n = 0]
 
-c) pred (sub 1 n) = 0
+c) [pred (sub 1 n) = 0]
 
-d) sub (S n) (S m) = sub n m
+d) [sub (S n) (S m) = sub n m]
 
 *)
 
 
-(** from exercises to Lecture 2: *)
+(** from exercises to Lecture 2 (of the UniMath school 2017): *)
 Definition ifbool (A : UU) (x y : A) : bool -> A :=
   bool_rect (λ _ : bool, A) x y.
 

--- a/2019-04-Birmingham/Part4_Tactics_UniMath/lecture_tactics_long_version.v
+++ b/2019-04-Birmingham/Part4_Tactics_UniMath/lecture_tactics_long_version.v
@@ -8,7 +8,7 @@
     The material is based on the extended version of the
     presentation at the UniMath school 2017 in Birmingham,
     but slightly enriched and later updated to fit with the
-    changes in UniMath until April 2018.
+    changes in UniMath.
 
     Works with UniMath current as of mid-March 2019.
 *)

--- a/2019-04-Birmingham/Part4_Tactics_UniMath/weq_exercises.v
+++ b/2019-04-Birmingham/Part4_Tactics_UniMath/weq_exercises.v
@@ -1,27 +1,59 @@
-(* Some exercises about equivalences *)
+(** *** Advanced exercise sheet for lecture 4: Tactics in Coq. *)
+
+(** Some exercises about equivalences - recall from the course that associativity
+    for products of types is not available "on the nose", i.e., just with equality.
+
+    Exercises originally suggested by Benedikt Ahrens and Anders Mörtberg
+    (for UniMath school 2017) and elaborated by Ralph Matthes (CNRS, IRIT,
+    Univ. Toulouse, France)
+*)
 Require Import UniMath.Foundations.PartA.
 
-(* Prove that the identity function is an equivalence *)
-Lemma idisweq (T : UU) : isweq (idfun T).
-Admitted.
+Locate "≃". (** written in Agda mode as [\simeq] *)
+Print weq.
+Print isweq.
+Print hfiber.
 
-(* Package this up as an equivalence *)
+Section weqdef.
+
+Variables X Y: UU.
+Eval compute in (X ≃ Y).
+(** there is a function [f] so that for given image [y] on can find the preimage [x] uniquely, but not only as element of [X] but even the pair consisting of the preimage and the proof that it is the preimage is unique. *)
+End weqdef.
+
+
+(** Prove that the identity function is an equivalence *)
+Lemma idisweq (X : UU) : isweq (idfun X).
+Abort.
+
+(** Package this up as an equivalence *)
 Definition idweq (X : UU) : X ≃ X.
-Admitted.
+Abort.
 
-(* Prove that any map to empty is an equivalence *)
+(** consider finding an alternative proof with [isweq_iso] that is extremely useful in the UniMath library *)
+
+
+(** Prove that any map to empty is an equivalence *)
 Lemma isweqtoempty {X : UU} (f : X -> ∅) : isweq f.
-Admitted.
+Abort.
 
-(* Package this up as an equivalence *)
+(** Package this up as an equivalence *)
 Definition weqtoempty {X : UU} (f : X -> ∅) : X ≃ ∅.
-Admitted.
+Abort.
 
-(* Prove that the composition of equivalences is an equivalence *)
+(** Prove that the composition of equivalences is an equivalence.
+
+This is rather difficult to do directly from the definition. Important lemmas
+to reason on equality of pairs in a sigma type are given by [base_paths] and
+[fiber_paths] that are elimination rules (that use given equality of pairs)
+and [total2_paths2_f] that is an introduction rule allowing to establish an
+equation between pairs. There, transport arises, but transport along the
+identity path is always the identity, and this already computationally, which
+means that [cbn] gets rid of it. *)
 Theorem compisweq {X Y Z : UU} (f : X -> Y) (g : Y -> Z)
         (isf : isweq f) (isg : isweq g) : isweq (g ∘ f).
-Admitted.
+Abort.
 
-(* Package this up as an equivalence *)
+(** Package this up as an equivalence *)
 Definition weqcomp {X Y Z : UU} (w1 : X ≃ Y) (w2 : Y ≃ Z) : X ≃ Z.
-Admitted.
+Abort.

--- a/2019-04-Birmingham/Part4_Tactics_UniMath/weq_exercises_with_solutions.v
+++ b/2019-04-Birmingham/Part4_Tactics_UniMath/weq_exercises_with_solutions.v
@@ -1,0 +1,195 @@
+(** *** Advanced exercise sheet for lecture 4: Tactics in Coq. *)
+
+(**
+    This is the material for the advisors with solutions.
+*)
+
+(** Some exercises about equivalences - recall from the course that associativity
+    for products of types is not available "on the nose", i.e., just with equality.
+
+    Exercises originally suggested by Benedikt Ahrens and Anders Mörtberg
+    (for UniMath school 2017) and elaborated by Ralph Matthes (CNRS, IRIT,
+    Univ. Toulouse, France)
+*)
+Require Import UniMath.Foundations.PartA.
+
+Locate "≃". (** written in Agda mode as [\simeq] *)
+Print weq.
+Print isweq.
+Print hfiber.
+
+Section weqdef.
+
+Variables X Y: UU.
+Eval compute in (X ≃ Y).
+(** there is a function [f] so that for given image [y] on can find the preimage [x] uniquely, but not only as element of [X] but even the pair consisting of the preimage and the proof that it is the preimage is unique. *)
+End weqdef.
+
+(** Prove that the identity function is an equivalence *)
+Lemma idisweq (X : UU) : isweq (idfun X).
+Proof.
+  unfold isweq.
+  intro y.
+  unfold iscontr.
+  unfold hfiber.
+  use tpair.
+  - exists y.
+    apply idpath.
+  - cbn.
+    intro p.
+    induction p as [x H].
+    unfold idfun in H.
+    rewrite H.
+    apply idpath.
+Defined.
+
+(** Package this up as an equivalence *)
+Definition idweq (X : UU) : X ≃ X.
+Proof.
+  exists (idfun X).
+  apply idisweq.
+Defined.
+
+(** alternative proof with [isweq_iso] that is extremely useful *)
+Lemma idisweq_alt (X : UU) : isweq (idfun X).
+Proof.
+  use isweq_iso.
+  - exact (fun x => x).
+  - cbn. intros x. apply idpath.
+  - cbn. intros x. apply idpath.
+Defined.
+
+(** Prove that any map to empty is an equivalence *)
+Lemma isweqtoempty {X : UU} (f : X -> ∅) : isweq f.
+Proof.
+  unfold isweq.
+  intro y.
+  induction y.
+Defined.
+
+(** Package this up as an equivalence *)
+Definition weqtoempty {X : UU} (f : X -> ∅) : X ≃ ∅.
+Proof.
+  use tpair.
+  - exact f.
+  - cbn. apply isweqtoempty.
+Defined.
+
+
+(** Prove that the composition of equivalences is an equivalence.
+
+This is rather difficult to do directly from the definition. Important lemmas
+to reason on equality of pairs in a sigma type are given by [base_paths] and
+[fiber_paths] that are elimination rules (that use given equality of pairs)
+and [total2_paths2_f] that is an introduction rule allowing to establish an
+equation between pairs. There, transport arises, but transport along the
+identity path is always the identity, and this already computationally, which
+means that [cbn] gets rid of it. *)
+Theorem compisweq {X Y Z : UU} (f : X -> Y) (g : Y -> Z)
+        (isf : isweq f) (isg : isweq g) : isweq (g ∘ f).
+Proof.
+  unfold isweq.
+  intro z.
+  unfold iscontr.
+  unfold hfiber.
+  set (isginst := isg z).
+  induction isginst as [cntrg Hg].
+  induction cntrg as [y yeq].
+  induction yeq. (** do this as early as possible *)
+  set (isfinst := isf y).
+  induction isfinst as [cntrf Hf].
+  induction cntrf as [x xeq].
+  induction xeq. (** again an early induction on an equation *)
+  use tpair.
+  - exists x.
+    apply idpath. (** thanks to the induction on equations, this is trivial *)
+  - cbn.
+    intro p.
+    induction p as [x' Hx'].
+    unfold funcomp in Hx'.
+    set (hfg := (f x',, Hx'): hfiber g (g (f x))).
+    set (Hginst := Hg hfg).
+    set (x'eq := base_paths _ _ Hginst).
+    cbn in x'eq.
+    set (hff := (x',,x'eq): hfiber f (f x)).
+    set (Hfinst := Hf hff).
+    set (x'eq' := base_paths _ _ Hfinst).
+    cbn in x'eq'.
+    assert (Hypg := fiber_paths Hginst). (** use [assert] to forget the definition *)
+    cbn in Hypg.
+    change (base_paths hfg (f x,, idpath (g (f x))) Hginst) with x'eq in Hypg.
+    assert (Hypf := fiber_paths Hfinst).
+    cbn in Hypf.
+    change (base_paths hff (x,, idpath (f x)) Hfinst) with x'eq' in Hypf.
+    induction x'eq'. (** this is now possible, after sufficient abstraction *)
+    use total2_paths2_f. (** a rather trivial instance *)
+    + apply idpath.
+    + cbn. unfold idfun.
+      cbn in Hypf. unfold idfun in Hypf.
+      rewrite Hypf in Hypg.
+      cbn in Hypg. unfold idfun in Hypg.
+      exact Hypg.
+Defined.
+
+(** a proof that is less aggressive on induction on identities - not completed *)
+Lemma compisweq_alt_incomplete {X Y Z : UU} (f : X -> Y) (g : Y -> Z)
+        (isf : isweq f) (isg : isweq g) : isweq (g ∘ f).
+Proof.
+  unfold isweq.
+  intro z.
+  unfold iscontr.
+  unfold hfiber.
+  set (isginst := isg z).
+  induction isginst as [cntrg Hg].
+  induction cntrg as [y yeq].
+  set (isfinst := isf y).
+  induction isfinst as [cntrf Hf].
+  induction cntrf as [x xeq].
+  use tpair.
+  - exists x.
+    unfold funcomp.
+    intermediate_path (g y).
+    + apply maponpaths.
+      apply xeq.
+    + apply yeq.
+  - cbn.
+    intro p.
+    induction p as [x' Hx'].
+    unfold funcomp in Hx'.
+    set (hfg := (f x',, Hx'): hfiber g z).
+    set (Hginst := Hg hfg).
+    set (x'eq := base_paths _ _ Hginst).
+    cbn in x'eq.
+    set (hff := (x',,x'eq): hfiber f y).
+    set (Hfinst := Hf hff).
+    set (x'eq' := base_paths _ _ Hfinst).
+    cbn in x'eq'.
+    set (Hypg := fiber_paths Hginst).
+    cbn in Hypg.
+    change (base_paths hfg (y,, yeq) Hginst) with x'eq in Hypg.
+    set (Hypf := fiber_paths Hfinst).
+    cbn in Hypf.
+    change (base_paths hff (x,, xeq) Hfinst) with x'eq' in Hypf.
+    use total2_paths2_f.
+    + exact x'eq'.
+    +
+
+      intermediate_path (transportf (λ x0 : hfiber f y, (g ∘ f) (pr1 x0) = z) Hfinst Hx').
+      { apply pathsinv0. unfold x'eq'. unfold base_paths. use functtransportf. }
+
+      assert (Hypg' : transportf (λ y0 : hfiber g z, g (pr1 y0) = z) Hginst Hx' = yeq).
+      { rewrite <- Hypg. unfold x'eq. unfold base_paths. use functtransportf. }
+
+      (** Who is willing to complete this proof? *)
+Abort.
+
+(** Package this up as an equivalence *)
+Definition weqcomp {X Y Z : UU} (w1 : X ≃ Y) (w2 : Y ≃ Z) : X ≃ Z.
+Proof.
+  induction w1 as [f isf].
+  induction w2 as [g isg].
+  use tpair.
+  - exact (g ∘ f).
+  - cbn.
+    exact (compisweq _ _ isf isg).
+Defined.


### PR DESCRIPTION
- since I do not know the material of the other parts this time, I refer to the UniMath school of 2017 for the material I reuse
- nothing deep on exercises_tactics.v or its solutions changed
- weq_exercises.v now comes with some small help - in 2017, the participants
  felt a bit lost
- weq_exercises_with_solutions.v has full solutions that are meant to be
  understandable by the participants (that do not require a deeper study
  of the UniMath library)

Finally, a mini-change on the extended course material - to answer to a question by Benedikt.