### PR TITLE
Update the URLs of ProofGeneral online doc

### DIFF
--- a/2017-12-Birmingham/Part2_Fundamentals_Coq/fundamentals_lecture.v
+++ b/2017-12-Birmingham/Part2_Fundamentals_Coq/fundamentals_lecture.v
@@ -81,8 +81,8 @@ C-x C-c      -- Kill Coq process
 >>
 For more commands see:
 
-https://proofgeneral.github.io/doc/userman/ProofGeneral_3/#Script-processing-commands
-https://proofgeneral.github.io/doc/userman/ProofGeneral_12/#Coq_002dspecific-commands
+https://proofgeneral.github.io/doc/master/userman/Basic-Script-Management/#Script-processing-commands
+https://proofgeneral.github.io/doc/master/userman/Coq-Proof-General/#Coq_002dspecific-commands
 
 Here C = CTRL and M = ALT on a standard emacs setup, so "C-c C-n"
 means "press c while holding CTRL and then press n while still holding

--- a/2019-04-Birmingham/Part2_Fundamentals_Coq/fundamentals_lecture.v
+++ b/2019-04-Birmingham/Part2_Fundamentals_Coq/fundamentals_lecture.v
@@ -86,8 +86,8 @@ C-x C-c      -- Kill the Coq process
 >>
 For more commands see:
 
-https://proofgeneral.github.io/doc/userman/ProofGeneral_3/#Script-processing-commands
-https://proofgeneral.github.io/doc/userman/ProofGeneral_12/#Coq_002dspecific-commands
+https://proofgeneral.github.io/doc/master/userman/Basic-Script-Management/#Script-processing-commands
+https://proofgeneral.github.io/doc/master/userman/Coq-Proof-General/#Coq_002dspecific-commands
 
 Here C = CTRL and M = ALT on a standard emacs setup, so "C-c C-n"
 means "press c while holding CTRL and then press n while still holding


### PR DESCRIPTION
Hello,

The naming convention of ProofGeneral documentation URLs has changed.
Some HTTPS redirects have been set up − cf. https://github.com/coq/coq/pull/10261#discussion_r289635960 −, unfortunately they do not support anchor redirection.
Hence this PR.

Kind regards,
Erik